### PR TITLE
Issue/1/non positive args cause type error

### DIFF
--- a/python/desc/primes/Primes.py
+++ b/python/desc/primes/Primes.py
@@ -6,6 +6,9 @@ Module to test for primes.
 def is_prime(number):
     "Test if number is prime."
 
+    if number <= 0:
+        raise TypeError("is_prime expects natural number argument")
+
     if number == 1:
         return False
 

--- a/tests/test_Primes.py
+++ b/tests/test_Primes.py
@@ -28,6 +28,11 @@ class PrimesTestCase(unittest.TestCase):
         "Test that a non-integer returns a TypeError."
         self.assertRaises(TypeError, is_prime, 3.14159)
 
+    def test_non_positive_integer_raises_type_error(self):
+        "Test that a non-positive integer returns a TypeError."
+        self.assertRaises(TypeError, is_prime, 0)
+        self.assertRaises(TypeError, is_prime, -1)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes #1.  An argument <=0 to `is_prime` will raise a TypeError:

```
>>> from desc.primes import Primes
>>> Primes.is_prime(0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/u1/jchiang/lsst/DESC/Meetings/Collaboration/2016-03/tutorial/tmp/Primes/python/desc/primes/Primes.py", line 10, in is_prime
    raise TypeError("is_prime expects natural number argument")
TypeError: is_prime expects natural number argument
>>> Primes.is_prime(-1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/u1/jchiang/lsst/DESC/Meetings/Collaboration/2016-03/tutorial/tmp/Primes/python/desc/primes/Primes.py", line 10, in is_prime
    raise TypeError("is_prime expects natural number argument")
TypeError: is_prime expects natural number argument
>>> 
```
